### PR TITLE
Let bot leave group

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.4",
-    "deltachat-node": "^1.0.0-alpha.11",
+    "deltachat-node": "^1.0.0-alpha.12",
     "ejs": "^3.0.1",
     "express": "^4.17.1",
     "express-session": "^1.17.0",

--- a/src/dc.js
+++ b/src/dc.js
@@ -52,6 +52,16 @@ dc.on('DC_EVENT_INCOMING_MSG', (...args) => handleDCMessage(dc, ...args))
 // dc.on('ALL', console.log.bind(null, 'core |'))// for debugging
 
 
+dc.on('DC_EVENT_SECUREJOIN_MEMBER_ADDED', function (chat_id, contact_id) {
+    console.log(`Group ${chat_id} was successfully created and joined by contact ${contact_id}`)
+    console.log(`Sending you-may-leave-message to chat ${chat_id}`)
+    dc.sendMessage(chat_id, "You may leave and remove this chat now.")
+    console.log(`Leaving chat ${chat_id}`)
+    dc.removeContactFromChat(chat_id, C.DC_CONTACT_ID_SELF)
+    console.log(`Deleting chat ${chat_id}`)
+    dc.deleteChat(chat_id)
+})
+
 dc.open(path.join(__dirname, '../data'), () => {
     if (!dc.isConfigured()) {
         dc.configure({


### PR DESCRIPTION
Let bot leave and delete group after the other contact joined the group. We then have verified them, and don't need the group chat anymore (the groups would linger in the database forever if we don't clean up).

Blocked by deltachat/deltachat-node#395